### PR TITLE
fix: reverse input text for Ivrit font to handle RTL rendering | The …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "asciified",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "asciified",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/node": "20.4.2",

--- a/src/app/helpers.ts
+++ b/src/app/helpers.ts
@@ -5,8 +5,12 @@ export const asyncFiglet = (
   text: string,
   options: figlet.Options = { font: "Standard" }
 ): Promise<string> => {
+  // Handle RTL fonts by reversing the input text
+  const isRTLFont = options.font === "Ivrit";
+  const processedText = isRTLFont ? text.split('').reverse().join('') : text;
+
   return new Promise((resolve, reject) => {
-    figlet.text(text, options as figlet.Options, (err, data) => {
+    figlet.text(processedText, options as figlet.Options, (err, data) => {
       if (err) {
         return reject(err);
       } else {


### PR DESCRIPTION
…Ivrit font was rendering text backwards due to RTL (Right-to-Left) handling. This commit fixes the issue by: adding RTL detection for Ivrit font in asyncFiglet helper, reversing input text before passing to figlet when Ivrit is used, and maintaining original behavior for all other fonts. This fix applies to both the web UI and API endpoints since they share the same helper function.